### PR TITLE
📦 Улучшения в генерации имени печатного файла и UX поля "бонусных копий"

### DIFF
--- a/src/entities/print-job/model/store.print-job.tsx
+++ b/src/entities/print-job/model/store.print-job.tsx
@@ -4,19 +4,29 @@ import { devtools } from "zustand/middleware";
 interface PrintJobStoreStore {
   printableFileName: string;
   orderName: string;
+  isOrderNameVisible: boolean;
+  toggleOrderNameVisible: () => void;
+  hideOrderName: () => void;
   setPrintableFileName: (name: string) => void;
   setOrderName: (name: string) => void;
   resetOrderName: () => void;
 }
 
 const usePrintJobStore = create<PrintJobStoreStore>()(
-  devtools((set) => ({
-    printableFileName: "",
-    orderName: "",
-    setPrintableFileName: (name: string) => set(() => ({ printableFileName: name })),
-    setOrderName: (name: string) => set(() => ({ orderName: name })),
-    resetOrderName: () => set(() => ({ orderName: "" })),
-  }))
+  devtools(
+    (set) => ({
+      printableFileName: "",
+      orderName: "",
+      isOrderNameVisible: false,
+      toggleOrderNameVisible: () =>
+        set((state) => ({ isOrderNameVisible: !state.isOrderNameVisible })),
+      hideOrderName: () => set(() => ({ isOrderNameVisible: false })),
+      setPrintableFileName: (name: string) => set(() => ({ printableFileName: name })),
+      setOrderName: (name: string) => set(() => ({ orderName: name })),
+      resetOrderName: () => set(() => ({ orderName: "" })),
+    }),
+    { name: "PrintJobStore" }
+  )
 );
 
 export default usePrintJobStore;

--- a/src/features/print-name-generator/bonus-copies/ui/BonusCopiesField.tsx
+++ b/src/features/print-name-generator/bonus-copies/ui/BonusCopiesField.tsx
@@ -5,6 +5,7 @@ import {
   filterInvalidChars,
 } from "@shared/lib/input-utils";
 import InputFieldShared from "@shared/ui/InputField";
+import { useAutoFocus } from "@shared/hooks";
 
 const MIN_BONUS_COPIES = 1;
 
@@ -22,6 +23,7 @@ const BonusCopiesField = ({
   className,
 }: BonusCopiesFieldProps) => {
   const [internalValue, setInternalValue] = useState(extraCopies.toString());
+  const { ref } = useAutoFocus<HTMLInputElement>();
 
   useEffect(() => {
     setInternalValue(extraCopies.toString());
@@ -37,6 +39,7 @@ const BonusCopiesField = ({
 
   return (
     <InputFieldShared
+      ref={ref}
       label="Бонусные копии:"
       placeholder={String(Math.max(extraCopies, MIN_BONUS_COPIES))}
       inputMode="numeric"

--- a/src/features/print-name-generator/calculation-result/model/usePrintableFileName.test.ts
+++ b/src/features/print-name-generator/calculation-result/model/usePrintableFileName.test.ts
@@ -23,7 +23,7 @@ describe("usePrintableFileName", () => {
     });
   });
 
-  it("должен обновлять имя файла при изменении orderName", () => {
+  it("должен обновлять имя файла при изменении если чекбокс поля включен", () => {
     const variants: Variant[] = [{ id: 1, itemsPerSheet: 50, numLabels: 1, totalQuantity: 100 }];
     const maxCopies = 5;
 
@@ -33,6 +33,7 @@ describe("usePrintableFileName", () => {
           setPrintableFileName,
           printableFileName: "",
           orderName,
+          orderNameVisible: true,
         });
 
         return usePrintableFileName({ variants, maxCopies });
@@ -48,6 +49,35 @@ describe("usePrintableFileName", () => {
 
     expect(setPrintableFileName).toHaveBeenCalledWith(
       "Order2 (100 шт. тираж + 150 шт. сверхтираж) 5 копий на печать"
+    );
+  });
+
+  it("должен НЕ обновлять имя файла при изменении если чекбокс поля ВЫКлючен", () => {
+    const variants: Variant[] = [{ id: 1, itemsPerSheet: 50, numLabels: 1, totalQuantity: 100 }];
+    const maxCopies = 5;
+
+    const { rerender } = renderHook(
+      ({ orderName }) => {
+        (usePrintJobStore as unknown as jest.Mock).mockReturnValue({
+          setPrintableFileName,
+          printableFileName: "",
+          orderName,
+          orderNameVisible: false,
+        });
+
+        return usePrintableFileName({ variants, maxCopies });
+      },
+      { initialProps: { orderName: "Order1" } }
+    );
+
+    expect(setPrintableFileName).toHaveBeenCalledWith(
+      "(100 шт. тираж + 150 шт. сверхтираж) 5 копий на печать"
+    );
+
+    rerender({ orderName: "Order2" });
+
+    expect(setPrintableFileName).toHaveBeenCalledWith(
+      "(100 шт. тираж + 150 шт. сверхтираж) 5 копий на печать"
     );
   });
 });

--- a/src/features/print-name-generator/calculation-result/model/usePrintableFileName.ts
+++ b/src/features/print-name-generator/calculation-result/model/usePrintableFileName.ts
@@ -16,16 +16,25 @@ export const usePrintableFileName = ({
   bonusCopies = 0,
   showOverprint = true,
 }: usePrintableFileNameProps) => {
-  const { setPrintableFileName, printableFileName, orderName } = usePrintJobStore();
+  const { setPrintableFileName, printableFileName, orderName, isOrderNameVisible } =
+    usePrintJobStore();
 
   useEffect(() => {
-    const orderNameWithSpace = orderName ?? "";
+    const orderNameTotal = isOrderNameVisible ? `${orderName} ` : "";
     const pcsAndPcsBonus = formatMultiVariant(variants, maxCopies, showOverprint);
     const bonusCopiesWithSpace = bonusCopies ? ` (${bonusCopies} из них — сверхтираж)` : "";
-    const totalName = `${orderNameWithSpace} ${pcsAndPcsBonus} ${maxCopies} копий на печать${bonusCopiesWithSpace}`;
+    const totalName = `${orderNameTotal}${pcsAndPcsBonus} ${maxCopies} копий на печать${bonusCopiesWithSpace}`;
 
     setPrintableFileName(totalName);
-  }, [bonusCopies, maxCopies, orderName, setPrintableFileName, showOverprint, variants]);
+  }, [
+    bonusCopies,
+    maxCopies,
+    orderName,
+    isOrderNameVisible,
+    setPrintableFileName,
+    showOverprint,
+    variants,
+  ]);
 
   return printableFileName;
 };

--- a/src/features/print-name-generator/order-name-management/index.ts
+++ b/src/features/print-name-generator/order-name-management/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./ui/OrderNameField";
+export { useOrderNameCheckbox } from "./model/useOrderNameCheckbox";

--- a/src/features/print-name-generator/order-name-management/model/useOrderNameCheckbox.tsx
+++ b/src/features/print-name-generator/order-name-management/model/useOrderNameCheckbox.tsx
@@ -1,0 +1,12 @@
+import { usePrintJobStore } from "@entities/print-job";
+import { useObserverReset } from "@entities/reset-manager";
+
+export const useOrderNameCheckbox = () => {
+  const { isOrderNameVisible, toggleOrderNameVisible, hideOrderName } = usePrintJobStore();
+
+  useObserverReset(hideOrderName);
+  return {
+    isOrderNameVisible,
+    toggleOrderNameVisible,
+  };
+};

--- a/src/features/print-name-generator/order-name-management/ui/OrderNameField.tsx
+++ b/src/features/print-name-generator/order-name-management/ui/OrderNameField.tsx
@@ -2,9 +2,11 @@ import style from "./OrderNameField.module.scss";
 import { useOrderName } from "../model/useOrderName";
 import InputField from "@shared/ui/InputField";
 import { replaceSpacesWithUnderscore } from "@shared/lib/utils.string";
+import { useAutoFocus } from "@shared/hooks";
 
 const OrderNameField = () => {
   const { orderNameLocal, setOrderNameLocal, setOrderName } = useOrderName();
+  const { ref } = useAutoFocus<HTMLInputElement>();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
@@ -15,6 +17,7 @@ const OrderNameField = () => {
   return (
     <div className={style.orderNameField}>
       <InputField
+        ref={ref}
         label={"Имя заказа"}
         value={orderNameLocal}
         placeholder={"Напишите имя заказа"}

--- a/src/pages/home/ui/Home.tsx
+++ b/src/pages/home/ui/Home.tsx
@@ -9,31 +9,40 @@ import {
 } from "@features/print-name-generator/bonus-copies";
 import { getMaxCopies } from "@features/print-name-generator/print-name";
 import {
-  VariantsList,
   ButtonAddVariant,
-  useVariants,
   CloneVariantButton,
+  useVariants,
+  VariantsList,
 } from "@features/print-name-generator/variant-management";
 import { ButtonResetGenerator } from "@features/print-name-generator/reset-generator-name";
 import {
   CalculationResult,
-  useTotalItemsCount,
-  useRemainingItems,
-  usePrintableFileName,
-  useMergedVariants,
   CopyToClipboardButton,
+  useMergedVariants,
+  usePrintableFileName,
+  useRemainingItems,
+  useTotalItemsCount,
 } from "@features/print-name-generator/calculation-result";
-import OrderNameField from "@features/print-name-generator/order-name-management";
+import OrderNameField, {
+  useOrderNameCheckbox,
+} from "@features/print-name-generator/order-name-management";
 import { Logo } from "@shared/ui/Logo";
+import Checkbox from "@shared/ui/Checkbox";
 
 const Home = () => {
   const { variants, setVariantField, addVariant, removeVariant, cloneVariant } = useVariants();
-  const { extraCopies, setExtraCopies, isVisible, toggleVisibility } = useBonusCopiesManager();
+  const {
+    extraCopies,
+    setExtraCopies,
+    isVisible: isBonusCopiesVisible,
+    toggleVisibility,
+  } = useBonusCopiesManager();
   const maxCopies = getMaxCopies(variants, extraCopies);
   const totalItemsCount = useTotalItemsCount(variants);
   const mergedVariants = useMergedVariants(variants);
   const remainingItems = useRemainingItems(totalItemsCount, maxCopies, variants);
   const { overPrintVisible, toggleOverPrint } = useOverPrintCheckbox();
+  const { isOrderNameVisible, toggleOrderNameVisible } = useOrderNameCheckbox();
 
   const printableFileName = usePrintableFileName({
     variants: mergedVariants,
@@ -48,7 +57,14 @@ const Home = () => {
         <OverPrintCheckbox checked={overPrintVisible} onChange={toggleOverPrint} />
       }
       bonusCopiesCheckbox={
-        <BonusCopiesCheckbox checked={isVisible} onChange={toggleVisibility} className={"test"} />
+        <BonusCopiesCheckbox checked={isBonusCopiesVisible} onChange={toggleVisibility} />
+      }
+      orderNameCheckBox={
+        <Checkbox
+          label={"Имя заказа"}
+          checked={isOrderNameVisible}
+          onChange={toggleOrderNameVisible}
+        />
       }
       title="Генератор имени файла для печати"
       resetButton={<ButtonResetGenerator className={styles.btnReset} />}
@@ -64,13 +80,15 @@ const Home = () => {
           copyToClipboardButton={<CopyToClipboardButton copyContent={printableFileName} />}
         />
       }
-      orderName={<OrderNameField />}
+      orderName={isOrderNameVisible && <OrderNameField />}
       extraCopiesInput={
-        <BonusCopiesField
-          isVisible={isVisible}
-          extraCopies={extraCopies}
-          onChange={(e) => setExtraCopies(Number(e.target.value))}
-        />
+        isBonusCopiesVisible && (
+          <BonusCopiesField
+            isVisible={isBonusCopiesVisible}
+            extraCopies={extraCopies}
+            onChange={(e) => setExtraCopies(Number(e.target.value))}
+          />
+        )
       }
       variantsTitle="Варианты раскладки на листе"
       variantsList={

--- a/src/pages/home/ui/LayoutComponent.module.scss
+++ b/src/pages/home/ui/LayoutComponent.module.scss
@@ -78,3 +78,14 @@
   flex-direction: column;
   gap: 12px;
 }
+
+.rowCheckbox {
+  display: flex;
+  gap: 32px;
+}
+
+.collumnCheckbox {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/pages/home/ui/LayoutComponent.tsx
+++ b/src/pages/home/ui/LayoutComponent.tsx
@@ -11,6 +11,7 @@ interface LayoutComponentProps {
   orderName: React.ReactNode;
   bonusCopiesCheckbox?: React.ReactNode;
   overPrintCheckbox?: React.ReactNode;
+  orderNameCheckBox?: React.ReactNode;
 }
 
 const LayoutComponent: React.FC<LayoutComponentProps> = ({
@@ -24,6 +25,7 @@ const LayoutComponent: React.FC<LayoutComponentProps> = ({
   orderName,
   bonusCopiesCheckbox,
   overPrintCheckbox,
+  orderNameCheckBox,
 }) => {
   return (
     <div className={styles.container}>
@@ -32,14 +34,24 @@ const LayoutComponent: React.FC<LayoutComponentProps> = ({
         {resetButton}
         {logo}
       </div>
-      {bonusCopiesCheckbox && <div>{bonusCopiesCheckbox}</div>}
-      {overPrintCheckbox && <div>{overPrintCheckbox}</div>}
+      <div className={styles.rowCheckbox}>
+        <div className={styles.collumnCheckbox}>
+          {bonusCopiesCheckbox && <div>{bonusCopiesCheckbox}</div>}
+          {overPrintCheckbox && <div>{overPrintCheckbox}</div>}
+        </div>
+
+        <div className={styles.collumnCheckbox}>
+          {orderNameCheckBox && <div>{orderNameCheckBox}</div>}
+        </div>
+      </div>
       {calculationResult}
 
-      <div className={styles.headerBox}>
-        {extraCopiesInput && <div className={styles.column}>{extraCopiesInput}</div>}
-        <div className={styles.column}>{orderName}</div>
-      </div>
+      {(orderName || extraCopiesInput) && (
+        <div className={styles.headerBox}>
+          {extraCopiesInput && <div className={styles.column}>{extraCopiesInput}</div>}
+          {orderName && <div className={styles.column}>{orderName}</div>}
+        </div>
+      )}
 
       <div className={styles.varintsBox}>
         <b className={styles.varintsTitle}>{variantsTitle}</b>

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useAutoFocus } from "./useAutoFocus";

--- a/src/shared/hooks/useAutoFocus.test.tsx
+++ b/src/shared/hooks/useAutoFocus.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { useAutoFocus } from "./useAutoFocus";
+
+const TestComponent = ({ shouldFocus = true }: { shouldFocus?: boolean }) => {
+  const { ref } = useAutoFocus<HTMLInputElement>(shouldFocus);
+
+  return <input ref={ref} data-testid="test-input" />;
+};
+
+describe("useAutoFocus", () => {
+  it("должен установить фокус при монтировании, если shouldFocus = true", () => {
+    render(<TestComponent />);
+    const input = screen.getByTestId("test-input");
+
+    // Проверка, что input получил фокус
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("не должен устанавливать фокус, если shouldFocus = false", () => {
+    render(<TestComponent shouldFocus={false} />);
+    const input = screen.getByTestId("test-input");
+
+    // Проверка, что input НЕ в фокусе
+    expect(document.activeElement).not.toBe(input);
+  });
+});

--- a/src/shared/hooks/useAutoFocus.ts
+++ b/src/shared/hooks/useAutoFocus.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "react";
+
+export const useAutoFocus = <T extends HTMLElement>(shouldFocus = true) => {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    if (!shouldFocus || !ref.current) return;
+    const element = ref.current;
+    element.focus();
+    return () => {
+      if (document.activeElement === element) {
+        element.blur();
+      }
+    };
+  }, [shouldFocus]);
+
+  return { ref };
+};

--- a/src/shared/ui/InputField/InputField.test.tsx
+++ b/src/shared/ui/InputField/InputField.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import InputField from "./InputField";
+import { useEffect, useRef } from "react";
 
 describe("Компонент InputField", () => {
   it("рендарит компонен", () => {
@@ -49,5 +50,24 @@ describe("Компонент InputField", () => {
 
     await userEvent.type(input, " world!");
     expect(handleChange).toHaveBeenCalledTimes(7);
+  });
+
+  it("передаёт ref и он указывает на input", () => {
+    const TestWithRef = () => {
+      const inputRef = useRef<HTMLInputElement>(null);
+
+      useEffect(() => {
+        if (inputRef.current) {
+          inputRef.current.setAttribute("data-ref-test", "true");
+        }
+      }, []);
+
+      return <InputField label="Name" ref={inputRef} />;
+    };
+
+    render(<TestWithRef />);
+    const input = screen.getByLabelText("Name");
+
+    expect(input).toHaveAttribute("data-ref-test", "true");
   });
 });

--- a/src/shared/ui/InputField/InputField.tsx
+++ b/src/shared/ui/InputField/InputField.tsx
@@ -1,34 +1,31 @@
 import clsx from "clsx";
 import styles from "./InputField.module.scss";
-import { useId } from "react";
+import { ComponentPropsWithRef, forwardRef, useId } from "react";
 
-interface InputFieldProps extends React.HTMLProps<HTMLInputElement> {
+interface InputFieldProps extends ComponentPropsWithRef<"input"> {
   label: string;
   inputClassName?: string;
   labelClassName?: string;
   wrapperClassName?: string;
 }
 
-const InputField = ({
-  label,
-  labelClassName,
-  inputClassName,
-  wrapperClassName,
-  ...props
-}: InputFieldProps) => {
-  const uniqueId = useId();
+const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
+  ({ label, labelClassName, inputClassName, wrapperClassName, ...props }, ref) => {
+    const uniqueId = useId();
 
-  return (
-    <div
-      className={clsx(styles.inputField, wrapperClassName)}
-      data-testid={`input-field-wrapper-${uniqueId}`}
-    >
-      <label className={clsx(styles.label, labelClassName)} htmlFor={uniqueId}>
-        {label}
-      </label>
-      <input {...props} className={clsx(styles.input, inputClassName)} id={uniqueId} />
-    </div>
-  );
-};
+    return (
+      <div
+        className={clsx(styles.inputField, wrapperClassName)}
+        data-testid={`input-field-wrapper-${uniqueId}`}
+      >
+        <label className={clsx(styles.label, labelClassName)} htmlFor={uniqueId}>
+          {label}
+        </label>
+        <input ref={ref} {...props} className={clsx(styles.input, inputClassName)} id={uniqueId} />
+      </div>
+    );
+  }
+);
 
+InputField.displayName = "InputField";
 export default InputField;


### PR DESCRIPTION
### ✨ Что сделано

- **store.print-job.tsx**:
  - Добавлено новое состояние `isOrderNameVisible` для управления отображением имени заказа.
  - Добавлены методы `toggleOrderNameVisible` и `hideOrderName` для управления этим состоянием.

- **usePrintableFileName**:
  - Обновлена логика генерации имени печатного файла:
    - Теперь учитывается флаг `isOrderNameVisible`. Если он `false`, имя заказа исключается из названия файла.
  - Добавлены тесты на новое поведение с учётом `orderNameVisible`.

- **BonusCopiesField.tsx**:
  - Добавлен хук `useAutoFocus`, чтобы автоматически фокусировать поле при отображении (улучшение UX).

### 🧪 Покрытие тестами

- Добавлены два новых юнит-теста:
  - Один проверяет генерацию с видимым `orderName`.
  - Второй — без `orderName`.

### 📌 Зачем это нужно

- Повышаем гибкость генерации имен файлов: можно скрывать имя заказа при необходимости.
- Облегчаем ввод бонусных копий для пользователя за счёт автопоказа клавиатуры (автофокуса).